### PR TITLE
New cli args (reportfile and reportfolder)

### DIFF
--- a/gui/src/main/java/org/verapdf/cli/VeraPdfCliProcessor.java
+++ b/gui/src/main/java/org/verapdf/cli/VeraPdfCliProcessor.java
@@ -101,7 +101,7 @@ final class VeraPdfCliProcessor {
         for (String pdfPath : pdfPaths) {
 			File file = new File(pdfPath);
             if (file.isDirectory()) {
-				baseDirectory = pdfPath;
+				baseDirectory = file.getAbsolutePath();
                 processDir(file);
             } else {
                 processFile(file);
@@ -175,7 +175,6 @@ final class VeraPdfCliProcessor {
 				reportFolderBuilder.append(reportFolder);
 			
 				String subDirectory = pdfFileDirectory.substring(baseDirectory.length());
-				reportFolderBuilder.append(File.separator);
 				reportFolderBuilder.append(subDirectory);
 				
 				reportFolder = reportFolderBuilder.toString();
@@ -184,7 +183,7 @@ final class VeraPdfCliProcessor {
 				
 				if (!dir.exists()) {
 					try {
-						dir.mkdir();
+						dir.mkdirs();
 					}
 					catch (SecurityException ex) {
 						LOGGER.error("Cannot create subdirectories the: " + ex.toString() + "\n");
@@ -200,7 +199,7 @@ final class VeraPdfCliProcessor {
             }
             catch (FileNotFoundException ex) {
                 outputReportStream = System.out;
-                stdOut = true;
+				stdOut = true;
             }
         }
         

--- a/gui/src/main/java/org/verapdf/cli/commands/VeraCliArgParser.java
+++ b/gui/src/main/java/org/verapdf/cli/commands/VeraCliArgParser.java
@@ -48,6 +48,8 @@ public class VeraCliArgParser {
 	final static String LOAD_CONFIG = OPTION_SEP + "config";
 	final static String PROFILES_WIKI = OPTION_SEP + "profilesWiki";
 	final static String USE_PLUGINS = OPTION_SEP + "plugins";
+	final static String REPORT_FILE = OPTION_SEP + "reportfile";
+	final static String REPORT_FOLDER = OPTION_SEP + "reportfolder";
 
 	@Parameter(names = { HELP_FLAG, HELP }, description = "Shows this message and exits.", help = true)
 	private boolean help = false;
@@ -102,6 +104,12 @@ public class VeraCliArgParser {
 
 	@Parameter(names = {USE_PLUGINS}, description = "Uses plugins in feature extracting.")
 	private boolean pluginsEnabled = false;
+        
+	@Parameter(names = { REPORT_FOLDER }, description = "Save reports in folder.")
+	private String reportFolder = "";
+        
+	@Parameter(names = { REPORT_FILE }, description = "Save report to file")
+	private String reportFile = "";
 
 	@Parameter(description = "FILES")
 	private List<String> pdfPaths = new ArrayList<>();
@@ -236,7 +244,23 @@ public class VeraCliArgParser {
 	 * @return true if plugins should be used in feature extracting
 	 */
 	public boolean isPluginsEnabled() { return pluginsEnabled; }
+        
+        /**
+         * @author: Martin.Mancuska@gonitrom.com
+         * @return folder for reports
+         */
+	public String getReportFolder() {
+	    return this.reportFolder;
+	}
 
+	/**
+     * @author: Martin.Mancuska@gonitrom.com
+	 * @return output file for report
+	 */
+	public String getReportFile() {
+	    return this.reportFile;
+	}
+        
 	/**
 	 * JCommander parameter converter for {@link FormatOption}, see
 	 * {@link IStringConverter} and {@link FormatOption#fromOption(String)}.

--- a/gui/src/main/java/org/verapdf/processor/config/Config.java
+++ b/gui/src/main/java/org/verapdf/processor/config/Config.java
@@ -40,6 +40,8 @@ public final class Config {
 	public static final PDFAFlavour DEFAULT_FLAVOUR = PDFAFlavour.PDFA_1_B;
 	public static final boolean DEFAULT_VERBOSE_CLI = false;
 	public static final boolean DEFAULT_PLUGINS_ENABLED = false;
+	public static final String DEFAULT_REPORT_FOLDER_PATH = "";
+	public static final String DEFAULT_REPORT_FILE_PATH = "";
 
 	private boolean showPassedRules;
 	private int maxNumberOfFailedChecks;
@@ -54,6 +56,8 @@ public final class Config {
 	private PDFAFlavour flavour;
 	private boolean verboseCli;
 	private boolean pluginsEnabled;
+	private String reportFolderPath;
+	private String reportFilePath;
 
 	@Override
 	public boolean equals(Object o) {
@@ -80,6 +84,11 @@ public final class Config {
 		if (reportType != config.reportType) return false;
 		if (validationProfilePath != null ? !validationProfilePath.equals(config.validationProfilePath) : config.validationProfilePath != null)
 			return false;
+		if (reportFolderPath != null ? !reportFolderPath.equals(config.reportFolderPath) : config.reportFolderPath != null)
+		    return false;
+		if (reportFilePath != null ? !reportFilePath.equals(config.reportFilePath) : config.reportFilePath != null)
+		    return false;
+                
 		return flavour == config.flavour;
 
 	}
@@ -99,6 +108,8 @@ public final class Config {
 		result = 31 * result + (flavour != null ? flavour.hashCode() : 0);
 		result = 31 * result + (verboseCli ? 1 : 0);
 		result = 31 * result + (pluginsEnabled ? 1 : 0);
+		result = 31 * result + (reportFolderPath != null ? reportFolderPath.hashCode() : 0);
+		result = 31 * result + (reportFilePath != null ? reportFilePath.hashCode() : 0);
 		return result;
 	}
 
@@ -116,6 +127,8 @@ public final class Config {
 		this.flavour = DEFAULT_FLAVOUR;
 		this.verboseCli = DEFAULT_VERBOSE_CLI;
 		this.pluginsEnabled = DEFAULT_PLUGINS_ENABLED;
+		this.reportFolderPath = DEFAULT_REPORT_FOLDER_PATH;
+		this.reportFilePath = DEFAULT_REPORT_FILE_PATH;
 	}
 
 	/**
@@ -201,7 +214,7 @@ public final class Config {
 		return validationProfilePath.toString().equals("") ?
 				null : validationProfilePath;
 	}
-
+        
 	/**
 	 * @return path to validation profile to be used. If returned value
 	 * is null, then validation flavour is processed
@@ -228,6 +241,24 @@ public final class Config {
 	 */
 	@XmlElement
 	public boolean isPluginsEnabled() { return pluginsEnabled; }
+        
+	/**
+     * @author: Martin.Mancuska@gonitrom.com
+     * @return path to folder for reports
+     */
+	@XmlElement
+	public String getReportFolder() {
+	    return reportFolderPath;
+	}
+
+	/** 
+     * @author: Martin.Mancuska@gonitrom.com
+	 * @return path for report file
+	 */
+	@XmlElement
+	public String getReportFile() {
+	    return reportFilePath;
+	}
 
 	/**
 	 *	Converts Config to XML,
@@ -444,6 +475,43 @@ public final class Config {
 	 */
 	public void setPluginsEnabled(boolean pluginsEnabled) {
 		this.pluginsEnabled = pluginsEnabled;
+	}
+        
+	/**
+	 * Changes settings parameters
+	 * 
+     * @author: Martin.Mancuska@gonitrom.com
+	 * @param reportFolder path to folder where results will be saved
+	 */
+	public void setReportFolderPath(String reportFolder) {
+        if (reportFolder.isEmpty())
+            this.reportFolderPath = reportFolder;
+        else {
+            File dir = new File(reportFolder);
+
+            if (dir.exists()) {
+                this.reportFolderPath = reportFolder;
+            }
+            else {
+                try {
+                    dir.mkdir();
+                    this.reportFolderPath = reportFolder;
+                }
+                catch (SecurityException ex) {
+                    this.reportFolderPath = "";
+                }
+            }    
+        }
+    }
+
+	/**
+	 * Changes settings parameters
+	 * 
+     * @author: Martin.Mancuska@gonitrom.com
+	 * @param reportFile path to report file
+	 */
+	public void setReportFilePath(String reportFile) {
+	    this.reportFilePath = reportFile;
 	}
 
 	/**

--- a/gui/src/main/java/org/verapdf/processor/config/Config.java
+++ b/gui/src/main/java/org/verapdf/processor/config/Config.java
@@ -494,7 +494,7 @@ public final class Config {
             }
             else {
                 try {
-                    dir.mkdir();
+                    dir.mkdirs();
                     this.reportFolderPath = reportFolder;
                 }
                 catch (SecurityException ex) {


### PR DESCRIPTION
new command line arguments added for cli version of verapdf-apps:
1. reportfile: redirect output from stdout to the file defined by user
2. reportfolder: for each tested pdf/a file create a separate report file in defined folder.

If both of them are defined on command line, then default behavior is switching back to STDOUT.