### PR TITLE
Signal abnormal exit after catching fatal errors

### DIFF
--- a/gui/src/main/java/org/verapdf/cli/VeraPdfCli.java
+++ b/gui/src/main/java/org/verapdf/cli/VeraPdfCli.java
@@ -39,7 +39,7 @@ public final class VeraPdfCli {
 	 *            using Apache commons CLI.
 	 */
 	public static void main(final String[] args) {
-	    MemoryMXBean memoryMan = ManagementFactory.getMemoryMXBean();
+		MemoryMXBean memoryMan = ManagementFactory.getMemoryMXBean();
 		ReleaseDetails.addDetailsFromResource(
 				ReleaseDetails.APPLICATION_PROPERTIES_ROOT + "app." + ReleaseDetails.PROPERTIES_EXT);
 		VeraCliArgParser cliArgParser = new VeraCliArgParser();
@@ -68,18 +68,20 @@ public final class VeraPdfCli {
 			} catch (IOException e) {
 				// TODO Auto-generated catch block
 				e.printStackTrace();
+				System.exit(1);
 			} catch (OutOfMemoryError oome) {
-	            MemoryUsage heapUsage = memoryMan.getHeapMemoryUsage();
-	            long maxMemory = heapUsage.getMax() / MEGABYTE;
-	            long usedMemory = heapUsage.getUsed() / MEGABYTE;
-	            System.out.println("The JVM appears to have run out of memory");
-	            System.out.println("Memory Use :" + usedMemory + "M/" + maxMemory + "M");
-	            System.out.println("To increase the memory available to the JVM please assign the JAVA_OPTS environment variable.");
-	            System.out.println("The examples below increase the maximum heap available to the JVM to 2GB:");
-	            System.out.println(" - Mac or Linux users: ");
-	            System.out.println("   export JAVA_OPTS=\"-Xmx2048m\"");
-	            System.out.println(" - Windows users: ");
-	            System.out.println("   SET JAVA_OPTS=\"-Xmx2048m\"");
+				MemoryUsage heapUsage = memoryMan.getHeapMemoryUsage();
+				long maxMemory = heapUsage.getMax() / MEGABYTE;
+				long usedMemory = heapUsage.getUsed() / MEGABYTE;
+				System.out.println("The JVM appears to have run out of memory");
+				System.out.println("Memory Use: " + usedMemory + "M/" + maxMemory + "M");
+				System.out.println("To increase the memory available to the JVM please assign the JAVA_OPTS environment variable.");
+				System.out.println("The examples below increase the maximum heap available to the JVM to 2GB:");
+				System.out.println(" - Mac or Linux users: ");
+				System.out.println("   export JAVA_OPTS=\"-Xmx2048m\"");
+				System.out.println(" - Windows users: ");
+				System.out.println("   SET JAVA_OPTS=\"-Xmx2048m\"");
+				System.exit(1);
 			}
 		}
 	}


### PR DESCRIPTION
The application now returns an error status code to the system
after an OOME or IO exception. It previously returned as normal.