### PR TITLE
FIX - Installer scripts with correct JAR file names

### DIFF
--- a/installer/src/main/resources/org/verapdf/scripts/verapdf-install.bat
+++ b/installer/src/main/resources/org/verapdf/scripts/verapdf-install.bat
@@ -36,7 +36,7 @@ goto Win9xApp
 :Win9xGetScriptDir
 set SAVEDIR=%CD%
 %0\
-cd %0\..\.. 
+cd %0\..\..
 set BASEDIR=%CD%
 cd %SAVEDIR%
 set SAVE_DIR=
@@ -45,7 +45,7 @@ goto repoSetup
 :WinNTGetScriptDir
 set BASEDIR=%~dp0\
 
-java -jar verapdf-izpack-installer-${project.version}.jar
+java -jar ${installer.output.filename}
 if %ERRORLEVEL% NEQ 0 goto error
 goto end
 

--- a/installer/src/main/resources/org/verapdf/scripts/verapdf-install.sh
+++ b/installer/src/main/resources/org/verapdf/scripts/verapdf-install.sh
@@ -76,4 +76,4 @@ if $cygwin; then
 fi
 
 cd $BASEDIR
-java -jar verapdf-izpack-installer-${project.version}.jar
+java -jar ${installer.output.filename}


### PR DESCRIPTION
- this affected the PDF box build when using the install script from the ZIP package; and
- now using Maven package variable name to populated templated startup scrip.


