### PR TITLE
FIX - Install scripts fail if spaces in jar path

### DIFF
--- a/installer/src/main/resources/org/verapdf/scripts/verapdf-install.bat
+++ b/installer/src/main/resources/org/verapdf/scripts/verapdf-install.bat
@@ -34,18 +34,19 @@ shift
 goto Win9xApp
 
 :Win9xGetScriptDir
-set SAVEDIR=%CD%
+set SAVEDIR="%CD%"
 %0\
 cd %0\..\..
 set BASEDIR=%CD%
-cd %SAVEDIR%
+echo %SAVEDIR%
+cd "%SAVEDIR%"
 set SAVE_DIR=
 goto repoSetup
 
 :WinNTGetScriptDir
 set BASEDIR=%~dp0\
 
-java -jar ${installer.output.filename}
+java -jar "%BASEDIR%${installer.output.filename}"
 if %ERRORLEVEL% NEQ 0 goto error
 goto end
 

--- a/installer/src/main/resources/org/verapdf/scripts/verapdf-install.sh
+++ b/installer/src/main/resources/org/verapdf/scripts/verapdf-install.sh
@@ -75,5 +75,6 @@ if $cygwin; then
   [ -n "$BASEDIR" ] && BASEDIR=`cygpath --path --windows "$BASEDIR"`
 fi
 
-cd $BASEDIR
+echo $BASEDIR
+cd "$BASEDIR"
 java -jar ${installer.output.filename}


### PR DESCRIPTION
- quoted cd path in bash script; and
- quoted java invocation path in batch script.
Closes #81