### PR TITLE
FIX - Handle spaces in Windows batch JAVACMD

### DIFF
--- a/installer/src/main/scripts/verapdf-gui.bat
+++ b/installer/src/main/scripts/verapdf-gui.bat
@@ -84,7 +84,7 @@ if NOT "%CLASSPATH_PREFIX%" == "" set CLASSPATH=%CLASSPATH_PREFIX%;%CLASSPATH%
 @REM Reaching here means variables are defined and arguments have been captured
 :endInit
 
-%JAVACMD% %JAVA_OPTS%  -classpath %CLASSPATH% -Dfile.encoding=UTF8 -Dapp.name="VeraPDF validation GUI" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" @verapdf.wrapper.gui@ %CMD_LINE_ARGS%
+"%JAVACMD%" %JAVA_OPTS%  -classpath %CLASSPATH% -Dfile.encoding=UTF8 -Dapp.name="VeraPDF validation GUI" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" @verapdf.wrapper.gui@ %CMD_LINE_ARGS%
 if %ERRORLEVEL% NEQ 0 goto error
 goto end
 

--- a/installer/src/main/scripts/verapdf.bat
+++ b/installer/src/main/scripts/verapdf.bat
@@ -84,7 +84,7 @@ if NOT "%CLASSPATH_PREFIX%" == "" set CLASSPATH=%CLASSPATH_PREFIX%;%CLASSPATH%
 @REM Reaching here means variables are defined and arguments have been captured
 :endInit
 
-%JAVACMD% %JAVA_OPTS%  -classpath %CLASSPATH% -Dfile.encoding=UTF8 -Dapp.name="VeraPDF validation GUI" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" @verapdf.wrapper.cli@ %CMD_LINE_ARGS%
+"%JAVACMD%" %JAVA_OPTS%  -classpath %CLASSPATH% -Dfile.encoding=UTF8 -Dapp.name="VeraPDF validation GUI" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" @verapdf.wrapper.cli@ %CMD_LINE_ARGS%
 if %ERRORLEVEL% NEQ 0 goto error
 goto end
 


### PR DESCRIPTION
- quoted JAVACMD for Java execution to handle spaces in path.

As suggested in #216