### PR TITLE
FIX - Java 9 startup scripts

### DIFF
--- a/installer/src/main/scripts/verapdf-gui.bat
+++ b/installer/src/main/scripts/verapdf-gui.bat
@@ -91,7 +91,7 @@ if NOT "%CLASSPATH_PREFIX%" == "" set CLASSPATH=%CLASSPATH_PREFIX%;%CLASSPATH%
 @REM If you have problems with a cramped window and invisible window controls you can increase the SCALE_FACTOR below to 1.5 or even 2.0
 set SCALE_FACTOR=1.0
 
-"%JAVACMD%" %JAVA_OPTS%  -classpath %CLASSPATH% -Dfile.encoding=UTF8 -Dapp.name="VeraPDF validation GUI" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" @verapdf.wrapper.gui@ --frameScale %SCALE_FACTOR% %CMD_LINE_ARGS%
+"%JAVACMD%" %JAVA_OPTS%  -classpath %CLASSPATH% -XX:+IgnoreUnrecognizedVMOptions --add-modules java.xml.bind -Dfile.encoding=UTF8 -Dapp.name="VeraPDF validation GUI" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" @verapdf.wrapper.gui@ --frameScale %SCALE_FACTOR% %CMD_LINE_ARGS%
 if %ERRORLEVEL% NEQ 0 goto error
 goto end
 

--- a/installer/src/main/scripts/verapdf-gui.sh
+++ b/installer/src/main/scripts/verapdf-gui.sh
@@ -128,6 +128,8 @@ SCALE_FACTOR=1.0
 exec "$JAVACMD" $JAVA_OPTS  \
   -classpath "$CLASSPATH" \
   -Dfile.encoding="UTF8" \
+  -XX:+IgnoreUnrecognizedVMOptions \
+  --add-modules=java.xml.bind \
   -Dapp.name="VeraPDF validation GUI" \
   -Dapp.pid="$$" \
   -Dapp.repo="$REPO" \

--- a/installer/src/main/scripts/verapdf.bat
+++ b/installer/src/main/scripts/verapdf.bat
@@ -84,7 +84,7 @@ if NOT "%CLASSPATH_PREFIX%" == "" set CLASSPATH=%CLASSPATH_PREFIX%;%CLASSPATH%
 @REM Reaching here means variables are defined and arguments have been captured
 :endInit
 
-"%JAVACMD%" %JAVA_OPTS%  -classpath %CLASSPATH% -Dfile.encoding=UTF8 -Dapp.name="VeraPDF validation GUI" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" @verapdf.wrapper.cli@ %CMD_LINE_ARGS%
+"%JAVACMD%" %JAVA_OPTS%  -classpath %CLASSPATH% -Dfile.encoding=UTF8 -XX:+IgnoreUnrecognizedVMOptions --add-modules java.xml.bind -Dapp.name="VeraPDF validation GUI" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" @verapdf.wrapper.cli@ %CMD_LINE_ARGS%
 if %ERRORLEVEL% NEQ 0 goto error
 goto end
 

--- a/installer/src/main/scripts/verapdf.sh
+++ b/installer/src/main/scripts/verapdf.sh
@@ -121,6 +121,8 @@ fi
 exec "$JAVACMD" $JAVA_OPTS  \
   -classpath "$CLASSPATH" \
   -Dfile.encoding="UTF8" \
+  -XX:+IgnoreUnrecognizedVMOptions \
+  --add-modules=java.xml.bind \
   -Dapp.name="VeraPDF validation CLI" \
   -Dapp.pid="$$" \
   -Dapp.repo="$REPO" \


### PR DESCRIPTION
- inserted --add-modules call JVM call in startup scripts; and
- added `-XX:+IgnoreUnrecognizedVMOptions` cludge to stop pre Java 9 complaints.