### PR TITLE
REL - Development version v1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 dist: trusty
 
 jdk:
-  - openjdk7
   - openjdk8
   - oraclejdk8
 

--- a/greenfield-apps/pom.xml
+++ b/greenfield-apps/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.verapdf</groupId>
     <artifactId>verapdf-apps</artifactId>
-    <version>1.10.0</version>
+    <version>1.11.0-SNAPSHOT</version>
   </parent>
   <groupId>org.verapdf.apps</groupId>
   <artifactId>greenfield-apps</artifactId>

--- a/gui/pom.xml
+++ b/gui/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.verapdf</groupId>
     <artifactId>verapdf-apps</artifactId>
-    <version>1.10.0</version>
+    <version>1.11.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.verapdf.apps</groupId>

--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.verapdf</groupId>
     <artifactId>verapdf-apps</artifactId>
-    <version>1.10.0</version>
+    <version>1.11.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.verapdf.apps</groupId>
@@ -38,10 +38,11 @@
   <properties>
     <installer.zip.prefix>verapdf-greenfield</installer.zip.prefix>
     <installer.output.filename>verapdf-izpack-installer-${project.version}.jar</installer.output.filename>
-    <izpack.version>5.0.0</izpack.version>
+    <izpack.version>5.1.2</izpack.version>
     <izpack.staging>${project.build.directory}/staging</izpack.staging>
     <izpack.target>${project.build.directory}</izpack.target>
     <izpack.scripts>${project.build.scriptSourceDirectory}</izpack.scripts>
+    <mvn.assembly.version>2.6</mvn.assembly.version>
     <project.main.dir>${project.basedir}/..</project.main.dir>
     <verapdf.apps.package>greenfield-apps</verapdf.apps.package>
     <verapdf.apps.package.name>Greenfield</verapdf.apps.package.name>
@@ -50,6 +51,15 @@
   </properties>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>${mvn.assembly.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pdfbox-apps/pom.xml
+++ b/pdfbox-apps/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.verapdf</groupId>
     <artifactId>verapdf-apps</artifactId>
-    <version>1.10.0</version>
+    <version>1.11.0-SNAPSHOT</version>
   </parent>
   <groupId>org.verapdf.apps</groupId>
   <artifactId>pdfbox-apps</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,12 +28,12 @@
   <parent>
     <artifactId>verapdf-parent</artifactId>
     <groupId>org.verapdf</groupId>
-    <version>1.4.1</version>
+    <version>1.12.2</version>
   </parent>
 
   <groupId>org.verapdf</groupId>
   <artifactId>verapdf-apps</artifactId>
-  <version>1.10.0</version>
+  <version>1.11.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>veraPDF PDF/A Validation Applications</name>
@@ -72,10 +72,9 @@
   <properties>
     <sonar.jacoco.itReportPath>${project.basedir}/../target/jacoco-it.exec</sonar.jacoco.itReportPath>
     <sonar.language>java</sonar.language>
-    <maven.failsafe.version>2.18.1</maven.failsafe.version>
-    <verapdf.library.version>[1.10.0,1.11.0)</verapdf.library.version>
-    <verapdf.pdfbox.validation.version>[1.10.0,1.11.0)</verapdf.pdfbox.validation.version>
-    <verapdf.validation.version>[1.10.0,1.11.0)</verapdf.validation.version>
+    <verapdf.library.version>[1.11.0,1.12.0)</verapdf.library.version>
+    <verapdf.pdfbox.validation.version>[1.11.0,1.12.0)</verapdf.pdfbox.validation.version>
+    <verapdf.validation.version>[1.11.0,1.12.0)</verapdf.validation.version>
   </properties>
 
   <dependencyManagement>
@@ -84,13 +83,13 @@
       <dependency>
         <groupId>com.beust</groupId>
         <artifactId>jcommander</artifactId>
-        <version>1.48</version>
+        <version>1.69</version>
       </dependency>
 
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>1.5.1</version>
+        <version>1.7.8</version>
         <scope>test</scope>
       </dependency>
 
@@ -132,7 +131,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.4</version>
         <configuration>
           <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
           <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
@@ -155,7 +153,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.3</version>
         <configuration>
           <show>public</show>
         </configuration>
@@ -172,7 +169,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
-            <version>2.10</version>
+            <version>3.0.2</version>
             <executions>
               <execution>
                 <id>sources-dependencies</id>
@@ -234,7 +231,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.0.0</version>
             <executions>
               <execution>
                 <id>src-vera</id>


### PR DESCRIPTION
- bumped minor version -> 1.11 for development;
- updated to parent 1.12.2 for Java 8 build;
- updated library, validation and pdfbox-validation dependencies;
- updated jcommander and equalsverifier dependencies;
- removed overridden Maven dependencies;
- updated izpack Maven plugin in installer module;
- overridden assembly plugin for installer module to downgrade to 2.6 for izpack; and
- removed OpenJDK 7 Travis job.