### PR TITLE
fix installer script not forwarding CLI args

### DIFF
--- a/installer/src/main/resources/org/verapdf/scripts/verapdf-install.sh
+++ b/installer/src/main/resources/org/verapdf/scripts/verapdf-install.sh
@@ -76,4 +76,4 @@ if $cygwin; then
 fi
 
 cd "$BASEDIR"
-java -jar ${installer.output.filename}
+java -jar ${installer.output.filename} "${@}"


### PR DESCRIPTION
This should fix https://github.com/veraPDF/veraPDF-library/issues/1021