### PR TITLE
FIX - Java 11 javax.xml.bind dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ notifications:
 
 before_install:
   - sudo apt-get install jq
-  - wget -O ~/codacy-coverage-reporter-assembly-latest.jar $(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r .assets[0].browser_download_url)
+  - wget -O ~/codacy-coverage-reporter-assembly-latest.jar http://resources.openpreservation.org/codacy-coverage-reporter-assembly-latest.jar
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/greenfield-apps/pom.xml
+++ b/greenfield-apps/pom.xml
@@ -44,7 +44,7 @@
 
     </plugins>
   </build>
-  
+
   <dependencies>
 
     <dependency>
@@ -52,13 +52,28 @@
       <artifactId>validation-model</artifactId>
       <version>${verapdf.validation.version}</version>
     </dependency>
-  
+
     <dependency>
       <groupId>org.verapdf.apps</groupId>
       <artifactId>gui</artifactId>
       <version>${project.version}</version>
     </dependency>
-  
+
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+     </dependency>
+
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/installer/src/main/scripts/verapdf-gui.bat
+++ b/installer/src/main/scripts/verapdf-gui.bat
@@ -91,7 +91,7 @@ if NOT "%CLASSPATH_PREFIX%" == "" set CLASSPATH=%CLASSPATH_PREFIX%;%CLASSPATH%
 @REM If you have problems with a cramped window and invisible window controls you can increase the SCALE_FACTOR below to 1.5 or even 2.0
 set SCALE_FACTOR=1.0
 
-"%JAVACMD%" %JAVA_OPTS%  -classpath %CLASSPATH% -XX:+IgnoreUnrecognizedVMOptions --add-modules=java.xml.bind -Dfile.encoding=UTF8 -Dapp.name="VeraPDF validation GUI" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" @verapdf.wrapper.gui@ --frameScale %SCALE_FACTOR% %CMD_LINE_ARGS%
+"%JAVACMD%" %JAVA_OPTS%  -classpath %CLASSPATH% -XX:+IgnoreUnrecognizedVMOptions -Dfile.encoding=UTF8 -Dapp.name="VeraPDF validation GUI" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" @verapdf.wrapper.gui@ --frameScale %SCALE_FACTOR% %CMD_LINE_ARGS%
 if %ERRORLEVEL% NEQ 0 goto error
 goto end
 

--- a/installer/src/main/scripts/verapdf-gui.sh
+++ b/installer/src/main/scripts/verapdf-gui.sh
@@ -129,7 +129,6 @@ exec "$JAVACMD" $JAVA_OPTS  \
   -classpath "$CLASSPATH" \
   -Dfile.encoding="UTF8" \
   -XX:+IgnoreUnrecognizedVMOptions \
-  --add-modules=java.xml.bind \
   -Dapp.name="VeraPDF validation GUI" \
   -Dapp.pid="$$" \
   -Dapp.repo="$REPO" \

--- a/installer/src/main/scripts/verapdf.bat
+++ b/installer/src/main/scripts/verapdf.bat
@@ -84,7 +84,7 @@ if NOT "%CLASSPATH_PREFIX%" == "" set CLASSPATH=%CLASSPATH_PREFIX%;%CLASSPATH%
 @REM Reaching here means variables are defined and arguments have been captured
 :endInit
 
-"%JAVACMD%" %JAVA_OPTS%  -classpath %CLASSPATH% -Dfile.encoding=UTF8 -XX:+IgnoreUnrecognizedVMOptions --add-modules=java.xml.bind -Dapp.name="VeraPDF validation GUI" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" @verapdf.wrapper.cli@ %CMD_LINE_ARGS%
+"%JAVACMD%" %JAVA_OPTS%  -classpath %CLASSPATH% -Dfile.encoding=UTF8 -XX:+IgnoreUnrecognizedVMOptions -Dapp.name="VeraPDF validation GUI" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" @verapdf.wrapper.cli@ %CMD_LINE_ARGS%
 if %ERRORLEVEL% NEQ 0 goto error
 goto end
 

--- a/installer/src/main/scripts/verapdf.sh
+++ b/installer/src/main/scripts/verapdf.sh
@@ -122,7 +122,6 @@ exec "$JAVACMD" $JAVA_OPTS  \
   -classpath "$CLASSPATH" \
   -Dfile.encoding="UTF8" \
   -XX:+IgnoreUnrecognizedVMOptions \
-  --add-modules=java.xml.bind \
   -Dapp.name="VeraPDF validation CLI" \
   -Dapp.pid="$$" \
   -Dapp.repo="$REPO" \

--- a/pdfbox-apps/pom.xml
+++ b/pdfbox-apps/pom.xml
@@ -64,11 +64,26 @@
       <artifactId>pdfbox-metadata-fixer</artifactId>
       <version>${verapdf.pdfbox.validation.version}</version>
     </dependency>
-  
+
     <dependency>
       <groupId>org.verapdf.apps</groupId>
       <artifactId>gui</artifactId>
       <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+     </dependency>
+
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,24 @@
       </dependency>
 
       <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>2.3.1</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <version>2.3.1</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-core</artifactId>
+        <version>2.3.0.1</version>
+      </dependency>
+
+      <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
         <version>1.7.8</version>


### PR DESCRIPTION
- added required dependencies to `pom.xml` dependencyManagement;
- added managed dependencies to `greenfield-apps/pom.xml` and `pdfbox-apps/pom.xml';
- removed `--add-modules=java.xml.bind` from all startup scripts as this fails from Java 11 onwards and the dependencies are now packaged; and
- now sourcing download from OPF site, updates happen less often.