### PR TITLE
FIX #1014

### DIFF
--- a/gui/src/main/java/org/verapdf/cli/VeraPdfCli.java
+++ b/gui/src/main/java/org/verapdf/cli/VeraPdfCli.java
@@ -18,6 +18,7 @@
 package org.verapdf.cli;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryUsage;
@@ -87,8 +88,12 @@ public final class VeraPdfCli {
 		}
 		messagesFromParser(cliArgParser);
 		if (isProcess(cliArgParser)) {
-			if (args.length == 0) {
-				jCommander.usage();
+			try {
+				if (args.length == 0 && System.in.available() == 0) {
+					jCommander.usage();
+				}
+			} catch (IOException e) {
+				logger.log(Level.SEVERE,"STDIN is not available", e);
 			}
 			try {
 				if (cliArgParser.isServerMode() || cliArgParser.getNumberOfProcesses() < 2) {


### PR DESCRIPTION
FIX STDIN : - output usage info when no parameter passed and added exception support
FIX output hint in processStdIn() method when no parameter,added exception support,added new method for write STDIN report
Copy from: https://github.com/veraPDF/veraPDF-apps/pull/252
Closes: veraPDF/veraPDF-library#1014