### PR TITLE
FIX: Install DOS batch param handling

### DIFF
--- a/installer/src/main/resources/org/verapdf/scripts/verapdf-install.bat
+++ b/installer/src/main/resources/org/verapdf/scripts/verapdf-install.bat
@@ -45,7 +45,7 @@ goto repoSetup
 :WinNTGetScriptDir
 set BASEDIR=%~dp0\
 
-java -jar "%BASEDIR%${installer.output.filename}"
+java -jar "%BASEDIR%${installer.output.filename}" %CMD_LINE_ARGS%
 if %ERRORLEVEL% NEQ 0 goto error
 goto end
 


### PR DESCRIPTION
- previously CL params were not passed to the installer making it
impossible to pass an auto-install config via the batch script;
- added CL params variable to JAR call; and
- fixed it.

Fixes veraPDF/veraPDF-library#1052