### PR TITLE
Fixed several issues with `exit-status.sh` script

### DIFF
--- a/tests/exit-status.sh
+++ b/tests/exit-status.sh
@@ -1,43 +1,50 @@
 #!/usr/bin/env bash
-# Grab the execution directory
-SCRIPT_DIR="$( dirname "$( readlink -f "${BASH_SOURCE[0]}" )")"
-export SCRIPT_DIR
 
-cd /tmp || exit
-if  [[ ! -e "./veraPDF-corpus-master" ]]
-then
+if (( NO_CD != 1 )); then
+  cd /tmp || exit
+fi
+
+if [[ ! -e "./veraPDF-corpus-master" ]]; then
   wget https://github.com/veraPDF/veraPDF-corpus/archive/master.zip
   unzip master.zip
   rm master.zip
 fi
-./verapdf/verapdf "./veraPDF-corpus-master/PDF_A-1b/6.1 File structure/6.1.4 Cross reference table/veraPDF test suite 6-1-4-t03-pass-b.pdf"
+
+if [[ -z "$VERAPDF" ]]; then
+  VERAPDF=./verapdf/verapdf
+fi
+
+"$VERAPDF" "./veraPDF-corpus-master/PDF_A-1b/6.1 File structure/6.1.4 Cross reference table/veraPDF test suite 6-1-4-t03-pass-b.pdf"
 resSinglePass=$?
-./verapdf/verapdf "./veraPDF-corpus-master/PDF_A-1b/6.1 File structure/6.1.4 Cross reference table/veraPDF test suite 6-1-4-t02-fail-a.pdf"
+"$VERAPDF" "./veraPDF-corpus-master/PDF_A-1b/6.1 File structure/6.1.4 Cross reference table/veraPDF test suite 6-1-4-t02-fail-a.pdf"
 resSingleFail=$?
-./verapdf/verapdf ./veraPDF-corpus-master/PDF_A-1b/6.1\ File\ structure/6.1.5\ Document\ information\ dictionary/veraPDF\ test\ suite\ 6-1-5-t02-pass-a.pdf ./veraPDF-corpus-master/PDF_A-1b/6.1\ File\ structure/6.1.5\ Document\ information\ dictionary/veraPDF\ test\ suite\ 6-1-5-t02-pass-b.pdf ./veraPDF-corpus-master/PDF_A-1b/6.1\ File\ structure/6.1.5\ Document\ information\ dictionary/veraPDF\ test\ suite\ 6-1-5-t02-pass-c.pdf
+"$VERAPDF" ./veraPDF-corpus-master/PDF_A-1b/6.1\ File\ structure/6.1.5\ Document\ information\ dictionary/veraPDF\ test\ suite\ 6-1-5-t02-pass-a.pdf ./veraPDF-corpus-master/PDF_A-1b/6.1\ File\ structure/6.1.5\ Document\ information\ dictionary/veraPDF\ test\ suite\ 6-1-5-t02-pass-b.pdf ./veraPDF-corpus-master/PDF_A-1b/6.1\ File\ structure/6.1.5\ Document\ information\ dictionary/veraPDF\ test\ suite\ 6-1-5-t02-pass-c.pdf
 resBatchPass=$?
-./verapdf/verapdf ./veraPDF-corpus-master/PDF_A-1b/6.1 File\ structure/6.1.5\ Document\ information\ dictionary/veraPDF\ test\ suite\ 6-1-5-t01-fail-a.pdf ./veraPDF-corpus-master/PDF_A-1b/6.1\ File\ structure/6.1.5\ Document\ information\ dictionary/veraPDF\ test\ suite\ 6-1-5-t01-fail-b.pdf ./veraPDF-corpus-master/PDF_A-1b/6.1\ File\ structure/6.1.5\ Document\ information\ dictionary/veraPDF\ test\ suite\ 6-1-5-t01-fail-c.pdf
+"$VERAPDF" ./veraPDF-corpus-master/PDF_A-1b/6.1 File\ structure/6.1.5\ Document\ information\ dictionary/veraPDF\ test\ suite\ 6-1-5-t01-fail-a.pdf ./veraPDF-corpus-master/PDF_A-1b/6.1\ File\ structure/6.1.5\ Document\ information\ dictionary/veraPDF\ test\ suite\ 6-1-5-t01-fail-b.pdf ./veraPDF-corpus-master/PDF_A-1b/6.1\ File\ structure/6.1.5\ Document\ information\ dictionary/veraPDF\ test\ suite\ 6-1-5-t01-fail-c.pdf
 resBatchFail=$?
-./verapdf/verapdf "./veraPDF-corpus-master/PDF_A-1b/6.1 File structure/6.1.5 Document information dictionary/"
+"$VERAPDF" "./veraPDF-corpus-master/PDF_A-1b/6.1 File structure/6.1.5 Document information dictionary/"
 resBatchPassFail=$?
-./verapdf/verapdf -f jbnd -m --params --help
+"$VERAPDF" -f jbnd -m --params --help
 resBadParams=$?
 export JAVA_OPTS="-Xmx2200k"
-./verapdf/verapdf "./veraPDF-corpus-master/PDF_A-1b/6.1 File structure/6.1.4 Cross reference table/"
+"$VERAPDF" "./veraPDF-corpus-master/PDF_A-1b/6.1 File structure/6.1.4 Cross reference table/"
 outOfMem=$?
 unset JAVA_OPTS
 touch test.pdf
-./verapdf/verapdf test.pdf
+"$VERAPDF" test.pdf
 parseError=$?
-echo ""
+
+echo
 echo "RESULTS"
 echo "======="
-echo " - single pass exit code:   ${resSinglePass}"
-echo " - single fail exit code:   ${resSingleFail}"
-echo " - batch pass exit code:    ${resBatchPass}"
-echo " - batch fail exit code:    ${resBatchFail}"
-echo " - batch mixed exit code:   ${resBatchPassFail}"
-echo " - bad params exit code:    ${resBadParams}"
-echo " - Out of memory exit code: ${outOfMem}"
-echo " - parse error exit code:   ${parseError}"
+echo " - single pass exit code:   $resSinglePass"
+echo " - single fail exit code:   $resSingleFail"
+echo " - batch pass exit code:    $resBatchPass"
+echo " - batch fail exit code:    $resBatchFail"
+echo " - batch mixed exit code:   $resBatchPassFail"
+echo " - bad params exit code:    $resBadParams"
+echo " - out of memory exit code: $outOfMem"
+echo " - parse error exit code:   $parseError"
+
+! [[ $resSinglePass || $resSingleFail || $resBatchPass || $resBatchFail || $resBatchPassFail || $resBadParams || $outOfMem || $parseError ]]
 exit


### PR DESCRIPTION
- Returns success/failure exit code based on whether all of the individual tests passed or not.
- Added options for specifying path of `verapdf` program (`VERAPDF`) and whether to change dir to /tmp first or not (`NO_CD`).
- Made use of `readlink` more robust — note that `-f` option is not available on BSD and macOS.

I am not sure if `SCRIPT_DIR` is actually used at all... it didn't seem to be. If so, maybe it can be removed.

Anyway, I am making these changes so that this test script can be used much more easily by packages in package managers (e.g., the Homebrew formula I use, which needs to run a test script). I have kept the default behaviour exactly the same as before, except that the script itself now changes its exit status. I hope this is okay.