### PR TITLE
Accept both exit codes 3 and 1 for out-of-memory test (temporary solution)

### DIFF
--- a/tests/exit-status.sh
+++ b/tests/exit-status.sh
@@ -45,6 +45,7 @@ expBatchFail=1
 expBatchPassFail=1
 expBadParams=2
 expOutOfMem=3
+expOutOfMemAlt=1 # HACK: accept alternative exit code 1 for out-of-memmory errors, for the time being.
 expParseError=7
 
 echo
@@ -56,10 +57,10 @@ echo " - batch pass exit code:    \t$resBatchPass\t(expected $expBatchPass)"
 echo " - batch fail exit code:    \t$resBatchFail\t(expected $expBatchFail)"
 echo " - batch mixed exit code:   \t$resBatchPassFail\t(expected $expBatchPassFail)"
 echo " - bad params exit code:    \t$resBadParams\t(expected $expBadParams)"
-echo " - out of memory exit code: \t$resOutOfMem\t(expected $expOutOfMem)"
+echo " - out of memory exit code: \t$resOutOfMem\t(expected $expOutOfMem or $expOutOfMemAlt)"
 echo " - parse error exit code:   \t$resParseError\t(expected $expParseError)"
 
-[[ $resSinglePass == $expSinglePass && $resSingleFail == $expSingleFail && $resBatchPass == $expBatchPass && $resBatchFail == $expBatchFail && $resBatchPassFail == $expBatchPassFail && $resBadParams == $expBadParams && $resOutOfMem == $expOutOfMem && $resParseError == $expParseError ]]
+[[ $resSinglePass == $expSinglePass && $resSingleFail == $expSingleFail && $resBatchPass == $expBatchPass && $resBatchFail == $expBatchFail && $resBatchPassFail == $expBatchPassFail && $resBadParams == $expBadParams && ($resOutOfMem == $expOutOfMem || $resOutOfMem = $expOutOfMemAlt) && $resParseError == $expParseError ]]
 passed=$?
 
 echo


### PR DESCRIPTION
Resolves issue mentioned in [this comment](https://github.com/veraPDF/veraPDF-apps/pull/300#issuecomment-987351660).

This can hopefully be reverted at some point in the future, per [this reply comment](https://github.com/veraPDF/veraPDF-apps/pull/300#issuecomment-990790000) by @bdoubrov.

> We'll try to come up with a more stable scenario to reproduce handled OOM. And then the script could be reverted back to expect only exit code 3.

CC @carlwilson