### PR TITLE
MERGE: Fix returning correct exit codes in case OOM and VeraPDF exceptions

### DIFF
--- a/gui/src/main/java/org/verapdf/cli/VeraPdfCliProcessor.java
+++ b/gui/src/main/java/org/verapdf/cli/VeraPdfCliProcessor.java
@@ -190,6 +190,12 @@ final class VeraPdfCliProcessor implements Closeable {
 		if (summary.getValidationSummary().getNonCompliantPdfaCount() > 0) {
 			return ExitCodes.INVALID;
 		}
+		if (summary.getOutOfMemory() > 0) {
+			return ExitCodes.OOM;
+		}
+		if (summary.getVeraExceptions() > 0) {
+			return ExitCodes.VERAPDF_EXCEPTION;
+		}
 		return ExitCodes.VALID;
 	}
 


### PR DESCRIPTION
This is a cherry-picked PR to patch 1.20 with the OOM and exception changes for veraPDF/veraPDF-library#1223.

This won't currently compile as it requires the library JAR created by  veraPDF/veraPDF-library#1248 