### PR TITLE
fix: update exit code for parse error

### DIFF
--- a/tests/exit-status.sh
+++ b/tests/exit-status.sh
@@ -46,7 +46,7 @@ expBatchPassFail=1
 expBadParams=2
 expOutOfMem=3
 expOutOfMemAlt=1 # HACK: accept alternative exit code 1 for out-of-memmory errors, for the time being.
-expParseError=7
+expParseError=9
 
 echo
 echo "RESULTS"


### PR DESCRIPTION
The parse error exit code needs update

```
==> /opt/homebrew/Cellar/verapdf/1.25.5/tests/exit-status.sh
Last 15 lines from /Users/rui/Library/Logs/Homebrew/verapdf/test.01.exit-status.sh:
  </batchSummary>
</report>

RESULTS
=======
 - single pass exit code:   	0	(expected 0)
 - single fail exit code:   	1	(expected 1)
 - batch pass exit code:    	0	(expected 0)
 - batch fail exit code:    	1	(expected 1)
 - batch mixed exit code:   	1	(expected 1)
 - bad params exit code:    	2	(expected 2)
 - out of memory exit code: 	3	(expected 3 or 1)
 - parse error exit code:   	9	(expected 7)
```

relates to https://github.com/Homebrew/homebrew-core/pull/134997