### PR TITLE
ci: add jdk21 support

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -7,11 +7,11 @@ on:
 jobs:
   build:
     name: Checkout and Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        java-version: [8, 11, 16, 17]
+        java-version: [8, 11, 16, 17, 21]
 
     steps:
       - uses: actions/checkout@v2
@@ -44,7 +44,7 @@ jobs:
 
   coverage:
     name: Quality Assurance
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [ build ]
 
     steps:

--- a/.github/workflows/update-arlington-workflow.yml
+++ b/.github/workflows/update-arlington-workflow.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [11, 16, 17]
+        java-version: [11, 16, 17, 21]
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Quick Start
 
 ### veraPDF GUI
 #### Download release version
-You can download a Java-based installer for the latest veraPDF GUI release [from our download site](https://software.verapdf.org/rel/verapdf-installer.zip). The current installation process requires Java 8 - 17 to be pre-installed.
+You can download a Java-based installer for the latest veraPDF GUI release [from our download site](https://software.verapdf.org/rel/verapdf-installer.zip). The current installation process requires Java 8 - 21 to be pre-installed.
 
 #### Download latest development version
 If you want to try the latest development version you can obtain it from our [development download site](https://software.verapdf.org/dev/verapdf-installer.zip). Be aware that we release development snapshots regularly, often more than once a day. While we try to ensure that development builds are well tested there are no guarantees.
@@ -68,7 +68,7 @@ Building the veraPDF-apps from Source
 
 In order to build this project you'll need:
 
- * Java 8 - 17, which can be downloaded [from Oracle](https://www.oracle.com/technetwork/java/javase/downloads/index.html), or for Linux users [OpenJDK](https://openjdk.java.net/install/index.html).
+ * Java 8 - 21, which can be downloaded [from Oracle](https://www.oracle.com/technetwork/java/javase/downloads/index.html), or for Linux users [OpenJDK](https://openjdk.java.net/install/index.html).
  * [Maven v3+](https://maven.apache.org/)
 
 Life will be easier if you also use [Git](https://git-scm.com/) to obtain and manage the source.


### PR DESCRIPTION
I have test out the jdk21 build and run, works fine for me, so adding the jdk21 support into the pipeline.

relates to https://github.com/Homebrew/homebrew-core/pull/160445