### PR TITLE
Update descriptions of CLI exit codes

### DIFF
--- a/gui/src/main/java/org/verapdf/cli/CliConstants.java
+++ b/gui/src/main/java/org/verapdf/cli/CliConstants.java
@@ -62,9 +62,9 @@ public final class CliConstants {
 	 */
 	public enum ExitCodes {
 		/** All files parsed and valid */
-		VALID(0, "All files validated."),
+		VALID(0, "All files validated and conform to the selected profile(s)."),
 		/** All files parsed, some invalid */
-		INVALID(1, "Invalid PDF/A file(s) found."),
+		INVALID(1, "All files validated, but at least one does not conform to the selected profile(s)."),
 		/** Bad command line parameters */
 		BAD_PARAMS(2, "Invalid command line parameters."),
 		/** Out of Memory */

--- a/tests/exit-status.sh
+++ b/tests/exit-status.sh
@@ -66,7 +66,7 @@ expBatchFail=1
 expBatchPassFail=1
 expBadParams=2
 expOutOfMem=3
-expOutOfMemAlt=1 # HACK: accept alternative exit code 1 for out-of-memmory errors, for the time being.
+expOutOfMemAlt=1 # HACK: accept alternative exit code 1 for out-of-memory errors, for the time being.
 expParseError=7
 
 echo


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Validation output messages were clarified to explicitly state whether all files conform to the selected PDF/A profile(s). Messages now distinguish between "all files validated and conform" and "all files validated, but at least one does not conform," giving clearer pass/fail guidance in CLI output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->